### PR TITLE
hotfix: handle Vercel 404 on page refresh for React routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ const __dirname = path.dirname(__filename);
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
### Issue
Refreshing any React route (e.g., /home) on production returns 404 on Vercel.

### Fix
Added vercel.json rewrite to redirect all unknown paths to index.html so React Router can handle routing.

### Tested
- Navigated to /home, /about, /contact
- Refreshed pages to confirm no 404